### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/RaspberryPi_JetsonNano/python/setup.py
+++ b/RaspberryPi_JetsonNano/python/setup.py
@@ -6,5 +6,11 @@ setup(
     author='Waveshare',
     package_dir={'': 'lib'},
     packages=['waveshare_epd'],
+    install_requires=[
+        'RPi.GPIO',
+        'spidev',
+        'Pillow',
+        'numpy'
+    ],
 )
 


### PR DESCRIPTION
This will automatically install the dependencies when waveshare_epd is installed, turning this
```
sudo apt-get update
sudo apt-get install python-pip
sudo apt-get install python-pil
sudo apt-get install python-numpy
sudo pip install RPi.GPIO
sudo pip install spidev
```
Into something like this
```
sudo apt-get update
sudo apt-get install python-pip
sudo python setup.py install
```